### PR TITLE
Fix: Call updates only on click interactable cards

### DIFF
--- a/src/components/layout/DrawPanel.tsx
+++ b/src/components/layout/DrawPanel.tsx
@@ -114,8 +114,8 @@ export default observer (class DrawPanel extends React.Component<IDrawPanelProps
                                         } else {
                                             c.activate()
                                         }
+                                        callUpdatePlayers(gameState.players)
                                     }
-                                    callUpdatePlayers(gameState.players)
                                 }
                                 return (
                                     <React.Fragment key={c._uid}>

--- a/src/components/layout/MarketPanel.tsx
+++ b/src/components/layout/MarketPanel.tsx
@@ -93,13 +93,13 @@ export default observer(class MarketPanel extends React.Component<IMarketPanelPr
                                         } else {
                                             gameState.buyCard(c)
                                         }
-                                    }
-                                    callUpdatePlayers(gameState.players)
-                                    callUpdateMarketDeck(gameState.marketDeck)
-                                    callUpdateMarketplace(gameState.marketplace)
-                                    if (headSector === Sector.Global || headSector === Sector.Snag) {
-                                        callUpdateLandfillPile(gameState.landfillPile)
-                                        callUpdateGlobalSlot(gameState.globalSlot)
+                                        callUpdatePlayers(gameState.players)
+                                        callUpdateMarketDeck(gameState.marketDeck)
+                                        callUpdateMarketplace(gameState.marketplace)
+                                        if (headSector === Sector.Global || headSector === Sector.Snag) {
+                                            callUpdateLandfillPile(gameState.landfillPile)
+                                            callUpdateGlobalSlot(gameState.globalSlot)
+                                        }
                                     }
                                 }
                                 return (


### PR DESCRIPTION
Now the updates aren't called on every card click, only the ones that to something.