### PR TITLE
Fix: Rise Special Rules text

### DIFF
--- a/src/components/PlayingCard.tsx
+++ b/src/components/PlayingCard.tsx
@@ -58,7 +58,7 @@ const PlayingCard = (props: ICardProps) => {
     const specialRuleStyle = {
         fontSize: 'xs',
         position: 'absolute',
-        top: '50%',
+        top: '40%',
         textAlign: 'center',
         width: '100%',
         px: 0


### PR DESCRIPTION
Rose Special Rules Text so it doesn't collide with Link Ability text on special cases.